### PR TITLE
Parse filter params

### DIFF
--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -30,6 +30,7 @@ use PrestaShopBundle\Exception\ProductNotFoundException;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class StockController extends Controller
 {
@@ -55,7 +56,7 @@ class StockController extends Controller
      */
     public function editProductAction($productId, Request $request)
     {
-        $quantity = (int) $request->request->get('quantity');
+        $quantity = $this->guardAgainstMissingQuantityParameter($request);
         $productId = (int) $productId;
 
         $productStockRepository = $this->get('prestashop.core.api.product_stock.repository');
@@ -79,7 +80,7 @@ class StockController extends Controller
      */
     public function editProductCombinationAction($productId, $productAttributeId, Request $request)
     {
-        $quantity = (int) $request->request->get('quantity');
+        $quantity = $this->guardAgainstMissingQuantityParameter($request);
         $productAttributeId = (int) $productAttributeId;
         $productId = (int) $productId;
 
@@ -99,4 +100,17 @@ class StockController extends Controller
 
         return new JsonResponse($product);
     }
+
+    /**
+     * @param Request $request
+     * @return int
+     */
+    private function guardAgainstMissingQuantityParameter(Request $request)
+    {
+        if (!$request->request->has('quantity')) {
+            throw new BadRequestHttpException('Missing "quantity" parameter');
+        }
+
+        return (int)$request->request->get('quantity');
+ti    }
 }

--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -38,15 +38,24 @@ class StockController extends Controller
      * @param Request $request
      * @return JsonResponse
      */
-    public function listAction(Request $request)
+    public function listProductsAction(Request $request)
     {
         $productStockRepository = $this->get('prestashop.core.api.product_stock.repository');
         $queryParamsCollection = $this->get('prestashop.core.api.query_params_collection');
 
         $queryParamsCollection = $queryParamsCollection->fromRequest($request);
-        $stockOverviewColumns = $productStockRepository->getStockOverviewRows($queryParamsCollection);
+        $stockOverviewColumns = $productStockRepository->getProducts($queryParamsCollection);
 
         return new JsonResponse($stockOverviewColumns);
+    }
+
+    /**
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function listProductCombinationsAction(Request $request)
+    {
+        return $this->listProductsAction($request);
     }
 
     /**
@@ -112,5 +121,5 @@ class StockController extends Controller
         }
 
         return (int)$request->request->get('quantity');
-ti    }
+    }
 }

--- a/src/PrestaShopBundle/Entity/Repository/ProductStockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/ProductStockRepository.php
@@ -127,58 +127,25 @@ class ProductStockRepository
     /**
      * @param $productId
      * @param $quantity
-     * @throws ProductNotFoundException
+     * @return mixed
      */
     public function updateProductQuantity($productId, $quantity)
     {
-        $query = '
-            UPDATE {prefix}stock_available
-            SET quantity = :quantity
-            WHERE id_product = :product_id
-            AND id_product_attribute = 0
-        ';
-
-        $query = str_replace('{prefix}', $this->tablePrefix, $query);
-
-        $statement = $this->connection->prepare($query);
-
-        $statement->bindValue('product_id', $productId, PDO::PARAM_INT);
-        $statement->bindValue('quantity', $quantity, PDO::PARAM_INT);
-
-        $statement->execute();
-
-        $andWhereClause = 'AND p.id_product = :product_id AND COALESCE(pa.id_product_attribute, 0) = 0';
-        $query = $this->selectProductStock($andWhereClause);
-
-        $query = str_replace('{prefix}', $this->tablePrefix, $query);
-
-        $statement = $this->connection->prepare($query);
-
-        $this->bindSelectProductStockParams($statement);
-        $statement->bindValue('product_id', $productId, PDO::PARAM_INT);
-
-        $statement->execute();
-
-        $rows = $statement->fetchAll();
-
-        if (count($rows) === 0) {
-            throw new ProductNotFoundException(sprintf('Product with id %d can not be found', $productId));
-        }
-
-        return $this->castNumericToInt($rows)[0];
+        return $this->updateProductCombinationQuantity($productId, 0, $quantity);
     }
 
     /**
      * @param $productId
      * @param $productAttributeId
      * @param $quantity
-     * @throws ProductNotFoundException
+     * @return mixed
      */
     public function updateProductCombinationQuantity($productId, $productAttributeId, $quantity)
     {
         $query = '
             UPDATE {prefix}stock_available
-            SET quantity = :quantity
+            SET quantity = :quantity,
+            physical_quantity = reserved_quantity + quantity
             WHERE id_product = :product_id
             AND id_product_attribute = :product_attribute_id
         ';
@@ -193,12 +160,22 @@ class ProductStockRepository
 
         $statement->execute();
 
+        return $this->getStockRowById($productId, $productAttributeId);
+    }
+
+    /**
+     * @param $productId
+     * @param $productAttributeId
+     * @return mixed
+     * @throws ProductNotFoundException
+     */
+    private function getStockRowById($productId, $productAttributeId)
+    {
         $andWhereClause = '
             AND p.id_product = :product_id AND 
             COALESCE(pa.id_product_attribute, 0) = :product_attribute_id'
         ;
         $query = $this->selectProductStock($andWhereClause);
-
         $query = str_replace('{prefix}', $this->tablePrefix, $query);
 
         $statement = $this->connection->prepare($query);

--- a/src/PrestaShopBundle/Entity/Repository/ProductStockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/ProductStockRepository.php
@@ -43,6 +43,8 @@ use Shop;
 
 class ProductStockRepository
 {
+    const MAX_COMBINATIONS_PER_PRODUCT = 50;
+
     /**
      * @var Connection
      */
@@ -215,7 +217,8 @@ class ProductStockRepository
 
         $orderClause = $this->getOrderClause($queryParams);
 
-        $query = $this->selectProductStock($andWhere = '', $orderClause);
+        $clauses = $this->getClausesRestrictingTotalCombinationsPerProduct();
+        $query = $this->selectProductStock($clauses['and_where'], $orderClause, $clauses['left_join']);
 
         $query = $query . $this->getLimitClause($queryParams);
 
@@ -276,16 +279,28 @@ class ProductStockRepository
     /**
      * @param string $andWhereClause
      * @param null $orderClause
+     * @param string $leftJoinClause
      * @return mixed
      */
-    private function selectProductStock($andWhereClause = '', $orderClause = null)
-    {
+    private function selectProductStock(
+        $andWhereClause = '',
+        $orderClause = null,
+        $leftJoinClause = ''
+    ) {
         if (is_null($orderClause)) {
             $orderClause = $this->getDefaultProductStockOrderClause();
         }
 
-        return str_replace('{and_where}', $andWhereClause, '
-            SELECT
+        return str_replace(
+            array(
+                '{and_where}',
+                '{left_join}'
+            ),
+            array(
+                $andWhereClause,
+                $leftJoinClause
+            ),
+            'SELECT
             p.id_product AS product_id,
             COALESCE(pa.id_product_attribute, 0) AS product_attribute_id,
             IF (LENGTH(p.reference) = 0, "N/A", p.reference) AS product_reference,
@@ -307,6 +322,7 @@ class ProductStockRepository
                 i.id_image = ims.id_image
             )
             LEFT JOIN {prefix}supplier s ON (p.id_supplier = s.id_supplier)
+            {left_join}
             WHERE
             ps.id_shop = :shop_id AND
             pl.id_lang = :language_id AND
@@ -320,6 +336,31 @@ class ProductStockRepository
     }
 
     /**
+     * @return string
+     */
+    public function getClausesRestrictingTotalCombinationsPerProduct()
+    {
+        return array(
+            'left_join' => '
+                LEFT JOIN (
+                    SELECT SUBSTRING_INDEX(
+                        GROUP_CONCAT(pa.id_product_attribute), 
+                        \',\', 
+                        :max_combinations_per_product
+                    ) product_attribute_ids, 
+                    pa.id_product 
+                    FROM ps_product_attribute pa 
+                    GROUP BY pa.id_product
+                ) select_ ON (COALESCE(FIND_IN_SET(pa.id_product_attribute, select_.product_attribute_ids), 0) > 0)',
+            'and_where' => '
+                AND (
+                    ISNULL(pa.id_product_attribute) OR
+                    NOT ISNULL(select_.product_attribute_ids)
+                )'
+        );
+    }
+    
+    /**
      * @param $statement
      */
     private function bindSelectProductStockParams(Statement $statement)
@@ -327,6 +368,7 @@ class ProductStockRepository
         $statement->bindValue('shop_id', $this->shopId, PDO::PARAM_INT);
         $statement->bindValue('language_id', $this->languageId, PDO::PARAM_INT);
         $statement->bindValue('state', Product::STATE_SAVED, PDO::PARAM_INT);
+        $statement->bindValue('max_combinations_per_product', self::MAX_COMBINATIONS_PER_PRODUCT, PDO::PARAM_INT);
     }
 
     /**

--- a/src/PrestaShopBundle/Entity/Repository/ProductStockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/ProductStockRepository.php
@@ -30,12 +30,12 @@ use Configuration;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Statement;
 use Employee;
+use PDO;
 use PrestaShop\PrestaShop\Adapter\ImageManager;
 use PrestaShop\PrestaShop\Adapter\LegacyContext as ContextAdapter;
 use PrestaShop\PrestaShop\Adapter\StockManager;
 use PrestaShopBundle\Api\QueryParamsCollection;
 use PrestaShopBundle\Exception\NotImplementedException;
-use PDO;
 use PrestaShopBundle\Exception\ProductNotFoundException;
 use Product;
 use RuntimeException;
@@ -81,7 +81,6 @@ class ProductStockRepository
     private $orderStates = array();
 
     /**
-     * ProductStockRepository constructor.
      * @param Connection $connection
      * @param ContextAdapter $contextAdapter
      * @param ImageManager $imageManager
@@ -162,7 +161,7 @@ class ProductStockRepository
 
         $statement->execute();
 
-        return $this->getStockRowById($productId, $productAttributeId);
+        return $this->selectProductsStockById($productId, $productAttributeId);
     }
 
     /**
@@ -171,18 +170,20 @@ class ProductStockRepository
      * @return mixed
      * @throws ProductNotFoundException
      */
-    private function getStockRowById($productId, $productAttributeId)
+    private function selectProductsStockById($productId, $productAttributeId)
     {
         $andWhereClause = '
             AND p.id_product = :product_id AND 
             COALESCE(pa.id_product_attribute, 0) = :product_attribute_id'
         ;
-        $query = $this->selectProductStock($andWhereClause);
-        $query = str_replace('{prefix}', $this->tablePrefix, $query);
+        $query = $this->selectProductsStock(
+            $leftJoinClause = '',
+            $andWhereClause
+        );
 
         $statement = $this->connection->prepare($query);
 
-        $this->bindSelectProductStockParams($statement);
+        $this->bindProductsSelectionValues($statement);
         $statement->bindValue('product_id', $productId, PDO::PARAM_INT);
         $statement->bindValue('product_attribute_id', $productAttributeId, PDO::PARAM_INT);
 
@@ -207,7 +208,7 @@ class ProductStockRepository
      * @param QueryParamsCollection $queryParams
      * @return mixed
      */
-    public function getStockOverviewRows(QueryParamsCollection $queryParams)
+    public function getProducts(QueryParamsCollection $queryParams)
     {
         $this->stockManager->updatePhysicalProductQuantity(
             $this->shopId,
@@ -215,31 +216,23 @@ class ProductStockRepository
             $this->orderStates['cancellation']
         );
 
-        $orderClause = $this->getOrderClause($queryParams);
-
-        $clauses = $this->getClausesRestrictingTotalCombinationsPerProduct();
-        $query = $this->selectProductStock($clauses['and_where'], $orderClause, $clauses['left_join']);
-
-        $query = $query . $this->getLimitClause($queryParams);
-
-        $query = str_replace('{prefix}', $this->tablePrefix, $query);
+        $query = $this->selectProductsStock(
+            $this->joinCeilingCombinationsPerProduct(),
+            $this->andWhere($queryParams),
+            $this->orderBy($queryParams)
+        ) . $this->paginate();
 
         $statement = $this->connection->prepare($query);
 
-        $this->bindSelectProductStockParams($statement);
-
-        $sqlClauses = $queryParams->toSqlClauses();
-        $limitClauseParams = $sqlClauses[$queryParams::SQL_CLAUSE_LIMIT_PARAMS];
-
-        foreach ($limitClauseParams  as $name => $value) {
-            $statement->bindValue($name, $value, PDO::PARAM_INT);
-        }
+        $this->bindProductsSelectionValues($statement);
+        $queryParams->bindValuesInStatement($statement);
+        $statement->bindValue('max_combinations_per_product', self::MAX_COMBINATIONS_PER_PRODUCT, PDO::PARAM_INT);
 
         $statement->execute();
 
         $rows = $statement->fetchAll();
 
-        $rows = $this->addImageThumbnailPath($rows);
+        $rows = $this->addImageThumbnailPaths($rows);
 
         return $this->castNumericToInt($rows);
     }
@@ -267,7 +260,7 @@ class ProductStockRepository
      * @param $rows
      * @return mixed
      */
-    private function addImageThumbnailPath($rows)
+    private function addImageThumbnailPaths($rows)
     {
         array_walk($rows, function (&$row) {
             $row['image_thumbnail_path'] = $this->imageManager->getThumbnailPath($row['image_id']);
@@ -277,28 +270,32 @@ class ProductStockRepository
     }
 
     /**
-     * @param string $andWhereClause
-     * @param null $orderClause
      * @param string $leftJoinClause
+     * @param string $andWhereClause
+     * @param null $orderByClause
      * @return mixed
      */
-    private function selectProductStock(
+    private function selectProductsStock(
+        $leftJoinClause = '',
         $andWhereClause = '',
-        $orderClause = null,
-        $leftJoinClause = ''
+        $orderByClause = null
     ) {
-        if (is_null($orderClause)) {
-            $orderClause = $this->getDefaultProductStockOrderClause();
+        if (is_null($orderByClause)) {
+            $orderByClause = $this->orderByProductIds();
         }
 
         return str_replace(
             array(
+                '{left_join}',
                 '{and_where}',
-                '{left_join}'
+                '{order_by}',
+                '{prefix}',
             ),
             array(
+                $leftJoinClause,
                 $andWhereClause,
-                $leftJoinClause
+                $orderByClause,
+                $this->tablePrefix,
             ),
             'SELECT
             p.id_product AS product_id,
@@ -332,49 +329,54 @@ class ProductStockRepository
             p.state = :state
             {and_where}
             GROUP BY p.id_product, COALESCE(pa.id_product_attribute, 0)
-        ' . $orderClause);
+            {order_by}
+        ');
     }
 
     /**
      * @return string
      */
-    public function getClausesRestrictingTotalCombinationsPerProduct()
+    public function joinCeilingCombinationsPerProduct()
     {
-        return array(
-            'left_join' => '
-                LEFT JOIN (
-                    SELECT SUBSTRING_INDEX(
-                        GROUP_CONCAT(pa.id_product_attribute), 
-                        \',\', 
-                        :max_combinations_per_product
-                    ) product_attribute_ids, 
-                    pa.id_product 
-                    FROM ps_product_attribute pa 
-                    GROUP BY pa.id_product
-                ) select_ ON (COALESCE(FIND_IN_SET(pa.id_product_attribute, select_.product_attribute_ids), 0) > 0)',
-            'and_where' => '
-                AND (
-                    ISNULL(pa.id_product_attribute) OR
-                    NOT ISNULL(select_.product_attribute_ids)
-                )'
-        );
+        return 'LEFT JOIN (
+            SELECT SUBSTRING_INDEX(
+                GROUP_CONCAT(pa.id_product_attribute), 
+                \',\', 
+                :max_combinations_per_product
+            ) product_attribute_ids, 
+            pa.id_product 
+            FROM ps_product_attribute pa 
+            GROUP BY pa.id_product
+        ) select_ ON (
+            COALESCE(FIND_IN_SET(pa.id_product_attribute, select_.product_attribute_ids), 0) > 0
+        ) ';
     }
-    
+
+    /**
+     * @return string
+     */
+    public function andWhereCeilingCombinationsPerProduct()
+    {
+        return 'AND (
+            ISNULL(pa.id_product_attribute) OR
+            NOT ISNULL(select_.product_attribute_ids)
+        ) ';
+    }
+
     /**
      * @param $statement
      */
-    private function bindSelectProductStockParams(Statement $statement)
+    private function bindProductsSelectionValues(Statement $statement)
     {
         $statement->bindValue('shop_id', $this->shopId, PDO::PARAM_INT);
         $statement->bindValue('language_id', $this->languageId, PDO::PARAM_INT);
         $statement->bindValue('state', Product::STATE_SAVED, PDO::PARAM_INT);
-        $statement->bindValue('max_combinations_per_product', self::MAX_COMBINATIONS_PER_PRODUCT, PDO::PARAM_INT);
     }
 
     /**
      * @return string
      */
-    private function getDefaultProductStockOrderClause()
+    private function orderByProductIds()
     {
         return 'ORDER BY p.id_product DESC, COALESCE(pa.id_product_attribute, 0)';
     }
@@ -383,18 +385,30 @@ class ProductStockRepository
      * @param QueryParamsCollection $queryParams
      * @return string
      */
-    private function getOrderClause(QueryParamsCollection $queryParams)
+    private function andWhere(QueryParamsCollection $queryParams)
     {
-        $sqlClauses = $queryParams->toSqlClauses();
+        $filter = $queryParams->getSqlFilter();
+        $filter = strtr($filter, array('{product_id}' => 'p.id_product'));
 
-        $descendingOrder = false !== strpos($sqlClauses[$queryParams::SQL_CLAUSE_ORDER], ' DESC');
+        return $this->andWhereCeilingCombinationsPerProduct() . $filter;
+    }
+
+    /**
+     * @param QueryParamsCollection $queryParams
+     * @return string
+     */
+    private function orderBy(QueryParamsCollection $queryParams)
+    {
+        $orderByClause = $queryParams->getSqlOrder();
+
+        $descendingOrder = false !== strpos($orderByClause, ' DESC');
 
         $productColumns = 'product_id, product_attribute_id';
         if ($descendingOrder) {
             $productColumns = 'product_id DESC, product_attribute_id ASC';
         }
 
-        return strtr($sqlClauses[$queryParams::SQL_CLAUSE_ORDER], array(
+        return strtr($orderByClause, array(
             '{product} DESC' => $productColumns,
             '{product}' => $productColumns,
             '{reference}' => 'product_reference',
@@ -405,13 +419,14 @@ class ProductStockRepository
     }
 
     /**
-     * @param QueryParamsCollection $queryParams
-     * @return mixed
+     * @return string
      */
-    private function getLimitClause(QueryParamsCollection $queryParams)
+    private function paginate()
     {
-        $sqlClauses = $queryParams->toSqlClauses();
-
-        return $sqlClauses[$queryParams::SQL_CLAUSE_LIMIT];
+        return sprintf(
+            'LIMIT :%s,:%s',
+            QueryParamsCollection::SQL_PARAM_FIRST_RESULT,
+            QueryParamsCollection::SQL_PARAM_MAX_RESULT
+        );
     }
 }

--- a/src/PrestaShopBundle/Resources/config/api/routing_stock_management.yml
+++ b/src/PrestaShopBundle/Resources/config/api/routing_stock_management.yml
@@ -1,16 +1,22 @@
-api_product_stock_list:
+api_stock_list_products:
     path: /stock
     methods: [GET]
     defaults:
-        _controller: PrestaShopBundle:Api/Stock:list
+        _controller: PrestaShopBundle:Api/Stock:listProducts
 
-api_product_stock_edit_product:
+api_stock_list_product_combinations:
+    path: /stock/{productId}
+    methods: [GET]
+    defaults:
+        _controller: PrestaShopBundle:Api/Stock:listProductCombinations
+
+api_stock_edit_product:
     path: /stock/product/{productId}
     methods: [POST]
     defaults:
         _controller: PrestaShopBundle:Api/Stock:editProduct
 
-api_product_stock_edit_product_combination:
+api_stock_edit_product_combination:
     path: /stock/product/{productId}/combination/{productAttributeId}
     methods: [POST]
     defaults:

--- a/tests/Integration/PrestaShopBundle/Controller/Api/StockControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/StockControllerTest.php
@@ -73,11 +73,25 @@ class StockControllerTest extends WebTestCase
         parent::tearDown();
     }
 
-    public function testListAction()
+    public function testListProductsAction()
     {
-        $listProductStockRoute = $this->router->generate('api_product_stock_list');
+        $this->assertOkResponseOnListProducts('api_stock_list_products');
+    }
 
-        $this->client->request('GET', $listProductStockRoute);
+    public function testListProductCombinationsAction()
+    {
+        $this->assertOkResponseOnListProducts('api_stock_list_product_combinations', array('productId' => 1));
+    }
+
+    /**
+     * @param $route
+     * @param array $parameters
+     */
+    private function assertOkResponseOnListProducts($route, $parameters = array())
+    {
+        $route = $this->router->generate($route, $parameters);
+
+        $this->client->request('GET', $route);
 
         $response = $this->client->getResponse();
 
@@ -100,7 +114,7 @@ class StockControllerTest extends WebTestCase
      */
     private function assertNotFoundResponseOnEditProductStockQuantity()
     {
-        $editProductStockRoute = $this->router->generate('api_product_stock_edit_product', array(
+        $editProductStockRoute = $this->router->generate('api_stock_edit_product', array(
             'productId' => 9,
         ));
 
@@ -118,7 +132,7 @@ class StockControllerTest extends WebTestCase
      */
     private function assertNotFoundResponseOnEditProductCombinationStockQuantity()
     {
-        $editProductStockRoute = $this->router->generate('api_product_stock_edit_product_combination', array(
+        $editProductStockRoute = $this->router->generate('api_stock_edit_product_combination', array(
             'productId' => 8,
             'productAttributeId' => 1
         ));
@@ -147,7 +161,7 @@ class StockControllerTest extends WebTestCase
 
     private function assertOkResponseOnEditProductCombinationQuantity()
     {
-        $editProductStockRoute = $this->router->generate('api_product_stock_edit_product_combination', array(
+        $editProductStockRoute = $this->router->generate('api_stock_edit_product_combination', array(
             'productId' => 1,
             'productAttributeId' => 1,
         ));

--- a/tests/Integration/PrestaShopBundle/Controller/Api/StockControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/StockControllerTest.php
@@ -152,8 +152,11 @@ class StockControllerTest extends WebTestCase
             'productAttributeId' => 1,
         ));
 
-        $expectedQuantity = 10;
-        $this->client->request('POST', $editProductStockRoute, array('quantity' => $expectedQuantity));
+        $expectedAvailableQuantity = 10;
+        $expectedPhysicalQuantity = 12;
+        $expectedReservedQuantity = 2;
+
+        $this->client->request('POST', $editProductStockRoute, array('quantity' => $expectedAvailableQuantity));
 
         /**
          * @var \Symfony\Component\HttpFoundation\JsonResponse $response
@@ -165,11 +168,24 @@ class StockControllerTest extends WebTestCase
         $content = $this->assertResponseBodyValidJson($response);
 
         $this->assertArrayHasKey('product_available_quantity', $content,
-            'The response body should contain a "product_available_quantity" property'
+            'The response body should contain a "product_available_quantity" property.'
+        );
+        $this->assertEquals($expectedAvailableQuantity, $content['product_available_quantity'],
+            'The response body should contain the newly updated physical quantity.'
         );
 
-        $this->assertEquals($expectedQuantity , $content['product_available_quantity'],
-            'The response body should contain the newly updated quantity'
+        $this->assertArrayHasKey('product_physical_quantity', $content,
+            'The response body should contain a "product_physical_quantity" property.'
+        );
+        $this->assertEquals($expectedPhysicalQuantity, $content['product_physical_quantity'],
+            'The response body should contain the newly updated quantity.'
+        );
+
+        $this->assertArrayHasKey('product_reserved_quantity', $content,
+            'The response body should contain a "product_reserved_quantity" property.'
+        );
+        $this->assertEquals($expectedReservedQuantity, $content['product_reserved_quantity'],
+            'The response body should contain the newly updated physical quantity.'
         );
     }
 


### PR DESCRIPTION
Usage examples:

Combinations of product with id #2

```
/api/stock/2
```

Sorting and pagination parameters can be applied to a subset of product combinations
Combinations of products with id #1 sorted by descending available quantity

```
/api/stock/1?order=available_quantity%20desc
```

Second page of products sorted by ascending supplier name, counting 3 products

```
/api/stock?order=supplier&page_size=3&page_index=2
```

@nihco2: Merging this PR requires updating routes nanes passed to `url` Twig function in `src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig`