### PR TITLE
Count total pages when requesting stock

### DIFF
--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -68,10 +68,10 @@ class StockManager implements \PrestaShopBundle\Service\DataProvider\StockInterf
         $this->updateReservedProductQuantity($shopId, $errorState, $cancellationState);
 
         $updatePhysicalQuantityQuery = '
-            UPDATE {prefix}stock_available sa
+            UPDATE {table_prefix}stock_available sa
             SET sa.physical_quantity = sa.quantity - sa.reserved_quantity
         ';
-        $updatePhysicalQuantityQuery = str_replace('{prefix}', _DB_PREFIX_, $updatePhysicalQuantityQuery);
+        $updatePhysicalQuantityQuery = str_replace('{table_prefix}', _DB_PREFIX_, $updatePhysicalQuantityQuery);
 
         return Db::getInstance()->execute($updatePhysicalQuantityQuery);
     }
@@ -84,14 +84,14 @@ class StockManager implements \PrestaShopBundle\Service\DataProvider\StockInterf
      */
     private function updateReservedProductQuantity($shopId, $errorState, $cancellationState)
     {
-        $updatePhysicalQuantityQuery = '
-            UPDATE {prefix}stock_available sa
+        $updateReservedQuantityQuery = '
+            UPDATE {table_prefix}stock_available sa
             SET sa.reserved_quantity = (
                 SELECT SUM(od.product_quantity - od.product_quantity_refunded)
-                FROM {prefix}orders o,
-                {prefix}order_history oh,
-                {prefix}order_state os,
-                {prefix}order_detail od
+                FROM {table_prefix}orders o,
+                {table_prefix}order_history oh,
+                {table_prefix}order_state os,
+                {table_prefix}order_detail od
                 WHERE
                 o.id_order = oh.id_order AND
                 o.current_state = oh.id_order_state AND
@@ -109,21 +109,22 @@ class StockManager implements \PrestaShopBundle\Service\DataProvider\StockInterf
             )
         ';
 
-        $updatePhysicalQuantityQuery = str_replace(
+        $updateReservedQuantityQuery = str_replace(
             array(
-                '{prefix}',
+                '{table_prefix}',
                 ':shop_id',
                 ':error_state',
                 ':cancellation_state',
-            ), array(
-                _DB_PREFIX_,
-                (int) $shopId,
-                (int) $errorState,
-                (int) $cancellationState
             ),
-            $updatePhysicalQuantityQuery
+            array(
+                _DB_PREFIX_,
+                (int)$shopId,
+                (int)$errorState,
+                (int)$cancellationState
+            ),
+            $updateReservedQuantityQuery
         );
 
-        return Db::getInstance()->execute($updatePhysicalQuantityQuery);
+        return Db::getInstance()->execute($updateReservedQuantityQuery);
     }
 }

--- a/src/PrestaShopBundle/Api/QueryParamsCollection.php
+++ b/src/PrestaShopBundle/Api/QueryParamsCollection.php
@@ -40,7 +40,7 @@ class QueryParamsCollection
 
     const SQL_PARAM_FIRST_RESULT = 'first_result';
 
-    const SQL_PARAM_MAX_RESULT = 'max_result';
+    const SQL_PARAM_MAX_RESULTS = 'max_result';
 
     /**
      * @var array
@@ -221,6 +221,18 @@ class QueryParamsCollection
         foreach ($sqlParams as $name => $value) {
             $statement->bindValue($name, $value, PDO::PARAM_INT);
         }
+    }
+
+    /**
+     * @param Statement $statement
+     */
+    public function bindMaxResultsParam(Statement $statement)
+    {
+        $paginationParams = $this->getSqlPaginationParams();
+        $statement->bindValue(
+            self::SQL_PARAM_MAX_RESULTS,
+            $paginationParams[self::SQL_PARAM_MAX_RESULTS]
+        );
     }
 
     /**

--- a/src/PrestaShopBundle/Api/QueryParamsCollection.php
+++ b/src/PrestaShopBundle/Api/QueryParamsCollection.php
@@ -28,9 +28,9 @@ namespace PrestaShopBundle\Api;
 
 use Doctrine\Common\Util\Inflector;
 use Doctrine\DBAL\Driver\Statement;
-use Symfony\Component\HttpFoundation\Request;
-use RangeException;
 use PDO;
+use PrestaShopBundle\Exception\InvalidPaginationParamsException;
+use Symfony\Component\HttpFoundation\Request;
 
 class QueryParamsCollection
 {
@@ -108,10 +108,16 @@ class QueryParamsCollection
             $queryParams['page_size'] > self::DEFAULT_PAGE_SIZE ||
             $queryParams['page_size'] < 1
         ) {
-            throw new RangeException(sprintf(
-                'The page size should be greater than 1 and fewer than %s',
-                self::DEFAULT_PAGE_SIZE
-            ));
+            throw new InvalidPaginationParamsException(
+                sprintf(
+                    'A page size should be an integer greater than 1 and fewer than %s',
+                    self::DEFAULT_PAGE_SIZE
+                )
+            );
+        }
+
+        if ($queryParams['page_index'] < 1) {
+            throw new InvalidPaginationParamsException();
         }
 
         return $queryParams;

--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -30,7 +30,7 @@ use PrestaShopBundle\Api\QueryParamsCollection;
 use PrestaShopBundle\Api\Stock\Movement;
 use PrestaShopBundle\Api\Stock\MovementsCollection;
 use PrestaShopBundle\Entity\ProductIdentity;
-use PrestaShopBundle\Entity\Repository\Stock\ProductRepository;
+use PrestaShopBundle\Entity\Repository\StockRepository;
 use PrestaShopBundle\Exception\InvalidPaginationParamsException;
 use PrestaShopBundle\Exception\ProductNotFoundException;
 use Psr\Log\LoggerInterface;
@@ -47,9 +47,9 @@ class StockController
     public $logger;
 
     /**
-     * @var ProductRepository
+     * @var StockRepository
      */
-    public $productRepository;
+    public $stockRepository;
 
     /**
      * @var QueryParamsCollection
@@ -73,10 +73,10 @@ class StockController
             return $this->handleException(new BadRequestHttpException($exception->getMessage(), $exception));
         }
 
-        $stockOverviewColumns = $this->productRepository->getProducts($queryParamsCollection);
-        $totalPages = $this->productRepository->countProductsPages($queryParamsCollection);
+        $stock = $this->stockRepository->getStock($queryParamsCollection);
+        $totalPages = $this->stockRepository->countStockPages($queryParamsCollection);
 
-        return new JsonResponse($stockOverviewColumns, 200, array('Total-Pages' => $totalPages));
+        return new JsonResponse($stock, 200, array('Total-Pages' => $totalPages));
     }
 
     /**
@@ -99,7 +99,7 @@ class StockController
 
         try {
             $movement = new Movement($productIdentity, $delta);
-            $product = $this->productRepository->updateProduct($movement);
+            $product = $this->stockRepository->updateStock($movement);
         } catch (ProductNotFoundException $exception) {
             return $this->handleException($exception);
         }
@@ -123,7 +123,7 @@ class StockController
         $movementsCollection = $this->movements->fromArray($stockMovementsParams);
 
         try {
-            $products = $this->productRepository->bulkUpdateProducts($movementsCollection);
+            $products = $this->stockRepository->bulkUpdateStock($movementsCollection);
         } catch (ProductNotFoundException $exception) {
             return $this->handleException($exception);
         }

--- a/src/PrestaShopBundle/Entity/Repository/Stock/ProductRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/Stock/ProductRepository.php
@@ -180,18 +180,14 @@ class ProductRepository
             COALESCE(pa.id_product_attribute, 0) = :combination_id'
         ;
         $query = $this->selectProductsStock(
+            $selectClause = null,
             $leftJoinClause = '',
             $andWhereClause
         );
 
         $statement = $this->connection->prepare($query);
-
-        $this->bindProductsSelectionValues($statement);
-        $statement->bindValue('product_id', $productIdentity->getProductId(), PDO::PARAM_INT);
-        $statement->bindValue('combination_id', $productIdentity->getCombinationId(), PDO::PARAM_INT);
-
+        $this->bindStockValues($statement, null, $productIdentity);
         $statement->execute();
-
         $rows = $statement->fetchAll();
 
         if (count($rows) === 0) {
@@ -222,24 +218,38 @@ class ProductRepository
         );
 
         $query = $this->selectProductsStock(
+            $selectClause = null,
             $this->joinCeilingCombinationsPerProduct(),
             $this->andWhere($queryParams),
+            $groupByClause = null,
             $this->orderBy($queryParams)
         ) . $this->paginate();
 
         $statement = $this->connection->prepare($query);
-
-        $this->bindProductsSelectionValues($statement);
-        $queryParams->bindValuesInStatement($statement);
-        $statement->bindValue('max_combinations_per_product', self::MAX_COMBINATIONS_PER_PRODUCT, PDO::PARAM_INT);
-
+        $this->bindStockValues($statement, $queryParams);
         $statement->execute();
-
         $rows = $statement->fetchAll();
-
         $rows = $this->addImageThumbnailPaths($rows);
 
         return $this->castNumericToInt($rows);
+    }
+
+    /**
+     * @param QueryParamsCollection $queryParams
+     * @return bool|string
+     */
+    public function countProductsPages(QueryParamsCollection $queryParams)
+    {
+        $query = sprintf(
+            'SELECT CEIL(FOUND_ROWS() / :%s) as total_pages',
+            QueryParamsCollection::SQL_PARAM_MAX_RESULTS
+        );
+
+        $statement = $this->connection->prepare($query);
+        $queryParams->bindMaxResultsParam($statement);
+        $statement->execute();
+
+        return (int)$statement->fetchColumn();
     }
 
     /**
@@ -288,58 +298,51 @@ class ProductRepository
     }
 
     /**
+     * @param null $selectClause
      * @param string $leftJoinClause
      * @param string $andWhereClause
+     * @param null $groupByClause
      * @param null $orderByClause
      * @return mixed
      */
     private function selectProductsStock(
+        $selectClause = null,
         $leftJoinClause = '',
         $andWhereClause = '',
+        $groupByClause = null,
         $orderByClause = null
     ) {
+        if (is_null($groupByClause)) {
+            $groupByClause = $this->groupByProductIds();
+        }
+
+        if (is_null($selectClause)) {
+            $selectClause = $this->getProductsStockColumns();
+        }
+
         if (is_null($orderByClause)) {
             $orderByClause = $this->orderByProductIds();
         }
 
         return str_replace(
             array(
+                '{select}',
                 '{left_join}',
                 '{and_where}',
+                '{group_by}',
                 '{order_by}',
                 '{prefix}',
             ),
             array(
+                $selectClause,
                 $leftJoinClause,
                 $andWhereClause,
+                $groupByClause,
                 $orderByClause,
                 $this->tablePrefix,
             ),
-            'SELECT
-            p.id_product AS product_id,
-            COALESCE(pa.id_product_attribute, 0) AS combination_id,
-            IF (
-                COALESCE(pa.reference, 0) = 0, 
-                IF (LENGTH(TRIM(p.reference)) > 0, p.reference, "N/A"),
-                IF (LENGTH(TRIM(pa.reference)) > 0, pa.reference, "N/A")
-            ) AS product_reference,
-            IF (
-                COALESCE(pa.id_product_attribute, 0) > 0,
-                GROUP_CONCAT(
-                  CONCAT(agl.name, " - ", al.name)  
-                  ORDER BY pa.id_product_attribute
-                  SEPARATOR ", " 
-                ),
-                "N/A"
-            ) AS combination_name,
-            p.id_supplier AS supplier_id,
-            COALESCE(ic.id_image, 0) AS product_cover_id,
-            COALESCE(i.id_image, 0) as combination_cover_id,
-            COALESCE(s.name, "N/A") AS supplier_name,
-            pl.name AS product_name,
-            sa.quantity as product_available_quantity,
-            sa.physical_quantity as product_physical_quantity,
-            sa.reserved_quantity as product_reserved_quantity
+            'SELECT SQL_CALC_FOUND_ROWS
+            {select}
             FROM {prefix}product p
             LEFT JOIN {prefix}product_attribute pa ON (p.id_product = pa.id_product)
             LEFT JOIN {prefix}product_lang pl ON (p.id_product = pl.id_product)
@@ -406,9 +409,42 @@ class ProductRepository
             sa.id_product_attribute = COALESCE(pa.id_product_attribute, 0) AND
             p.state = :state
             {and_where}
-            GROUP BY p.id_product, COALESCE(pa.id_product_attribute, 0) 
+            {group_by} 
             {order_by}
         ');
+    }
+
+    /**
+     * @return string
+     */
+    private function getProductsStockColumns()
+    {
+        return '
+            p.id_product AS product_id,
+            COALESCE(pa.id_product_attribute, 0) AS combination_id,
+            IF (
+            COALESCE(pa.reference, 0) = 0, 
+                IF (LENGTH(TRIM(p.reference)) > 0, p.reference, "N/A"),
+                IF (LENGTH(TRIM(pa.reference)) > 0, pa.reference, "N/A")
+            ) AS product_reference,
+            IF (
+                COALESCE(pa.id_product_attribute, 0) > 0,
+                GROUP_CONCAT(
+                    CONCAT(agl.name, " - ", al.name)  
+                  ORDER BY pa.id_product_attribute
+                  SEPARATOR ", " 
+                ),
+                "N/A"
+            ) AS combination_name,
+            p.id_supplier AS supplier_id,
+            COALESCE(ic.id_image, 0) AS product_cover_id,
+            COALESCE(i.id_image, 0) as combination_cover_id,
+            COALESCE(s.name, "N/A") AS supplier_name,
+            pl.name AS product_name,
+            sa.quantity as product_available_quantity,
+            sa.physical_quantity as product_physical_quantity,
+            sa.reserved_quantity as product_reserved_quantity
+        ';
     }
 
     /**
@@ -441,13 +477,29 @@ class ProductRepository
     }
 
     /**
-     * @param $statement
+     * @param Statement $statement
+     * @param QueryParamsCollection|null $queryParams
+     * @param ProductIdentity|null $productIdentity
      */
-    private function bindProductsSelectionValues(Statement $statement)
+    private function bindStockValues(
+        Statement $statement,
+        QueryParamsCollection $queryParams = null,
+        ProductIdentity $productIdentity = null
+    )
     {
         $statement->bindValue('shop_id', $this->shopId, PDO::PARAM_INT);
         $statement->bindValue('language_id', $this->languageId, PDO::PARAM_INT);
         $statement->bindValue('state', Product::STATE_SAVED, PDO::PARAM_INT);
+
+        if ($queryParams) {
+            $queryParams->bindValuesInStatement($statement);
+            $statement->bindValue('max_combinations_per_product', self::MAX_COMBINATIONS_PER_PRODUCT, PDO::PARAM_INT);
+        }
+
+        if ($productIdentity) {
+            $statement->bindValue('product_id', $productIdentity->getProductId(), PDO::PARAM_INT);
+            $statement->bindValue('combination_id', $productIdentity->getCombinationId(), PDO::PARAM_INT);
+        }
     }
 
     /**
@@ -456,6 +508,14 @@ class ProductRepository
     private function orderByProductIds()
     {
         return 'ORDER BY p.id_product DESC, COALESCE(pa.id_product_attribute, 0)';
+    }
+
+    /**
+     * @return string
+     */
+    private function groupByProductIds()
+    {
+        return 'GROUP BY p.id_product, COALESCE(pa.id_product_attribute, 0)';
     }
 
     /**
@@ -503,7 +563,7 @@ class ProductRepository
         return sprintf(
             'LIMIT :%s,:%s',
             QueryParamsCollection::SQL_PARAM_FIRST_RESULT,
-            QueryParamsCollection::SQL_PARAM_MAX_RESULT
+            QueryParamsCollection::SQL_PARAM_MAX_RESULTS
         );
     }
 }

--- a/src/PrestaShopBundle/Entity/Repository/StockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockRepository.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShopBundle\Entity\Repository\Stock;
+namespace PrestaShopBundle\Entity\Repository;
 
 use Configuration;
 use Doctrine\DBAL\Driver\Connection;
@@ -44,7 +44,7 @@ use Product;
 use RuntimeException;
 use Shop;
 
-class ProductRepository
+class StockRepository
 {
     const MAX_COMBINATIONS_PER_PRODUCT = 50;
 
@@ -97,7 +97,8 @@ class ProductRepository
         ImageManager $imageManager,
         StockManager $stockManager,
         $tablePrefix
-    ) {
+    )
+    {
         $this->connection = $connection;
         $this->imageManager = $imageManager;
         $this->stockManager = $stockManager;
@@ -111,7 +112,7 @@ class ProductRepository
         }
 
         $languageId = $context->employee->id_lang;
-        $this->languageId = (int) $languageId;
+        $this->languageId = (int)$languageId;
 
         if (!$context->shop instanceof Shop) {
             throw new RuntimeException('Determining the active shop requires a contextual shop instance.');
@@ -122,8 +123,8 @@ class ProductRepository
             throw new NotImplementedException('Shop context types other than "single shop" are not supported');
         }
 
-        $this->orderStates['error'] = (int) Configuration::get('PS_OS_ERROR');
-        $this->orderStates['cancellation'] = (int) Configuration::get('PS_OS_CANCELED');
+        $this->orderStates['error'] = (int)Configuration::get('PS_OS_ERROR');
+        $this->orderStates['cancellation'] = (int)Configuration::get('PS_OS_CANCELED');
 
         $this->shopId = $shop->getContextualShopId();
     }
@@ -132,10 +133,10 @@ class ProductRepository
      * @param MovementsCollection $movements
      * @return array
      */
-    public function bulkUpdateProducts(MovementsCollection $movements)
+    public function bulkUpdateStock(MovementsCollection $movements)
     {
         return $movements->map(function (Movement $movement) {
-            return $this->updateProduct($movement);
+            return $this->updateStock($movement);
         });
     }
 
@@ -143,17 +144,17 @@ class ProductRepository
      * @param Movement $movement
      * @return mixed
      */
-    public function updateProduct(Movement $movement)
+    public function updateStock(Movement $movement)
     {
         $query = '
-            UPDATE {prefix}stock_available
+            UPDATE {table_prefix}stock_available
             SET quantity = quantity + :delta,
             physical_quantity = reserved_quantity + quantity
             WHERE id_product = :product_id
             AND id_product_attribute = :combination_id
         ';
 
-        $query = str_replace('{prefix}', $this->tablePrefix, $query);
+        $query = str_replace('{table_prefix}', $this->tablePrefix, $query);
 
         $statement = $this->connection->prepare($query);
 
@@ -166,27 +167,26 @@ class ProductRepository
 
         $statement->execute();
 
-        return $this->selectProductsStockById($productIdentity);
+        return $this->selectStockBy($productIdentity);
     }
 
     /**
      * @param ProductIdentity $productIdentity
      * @return mixed
      */
-    private function selectProductsStockById(ProductIdentity $productIdentity)
+    private function selectStockBy(ProductIdentity $productIdentity)
     {
         $andWhereClause = '
-            AND p.id_product = :product_id AND 
-            COALESCE(pa.id_product_attribute, 0) = :combination_id'
-        ;
-        $query = $this->selectProductsStock(
-            $selectClause = null,
+            AND p.id_product = :product_id 
+            AND COALESCE(pa.id_product_attribute, 0) = :combination_id';
+        $query = $this->selectStock(
             $leftJoinClause = '',
             $andWhereClause
         );
 
         $statement = $this->connection->prepare($query);
         $this->bindStockValues($statement, null, $productIdentity);
+
         $statement->execute();
         $rows = $statement->fetchAll();
 
@@ -209,7 +209,7 @@ class ProductRepository
      * @param QueryParamsCollection $queryParams
      * @return mixed
      */
-    public function getProducts(QueryParamsCollection $queryParams)
+    public function getStock(QueryParamsCollection $queryParams)
     {
         $this->stockManager->updatePhysicalProductQuantity(
             $this->shopId,
@@ -217,18 +217,18 @@ class ProductRepository
             $this->orderStates['cancellation']
         );
 
-        $query = $this->selectProductsStock(
-            $selectClause = null,
-            $this->joinCeilingCombinationsPerProduct(),
-            $this->andWhere($queryParams),
-            $groupByClause = null,
-            $this->orderBy($queryParams)
-        ) . $this->paginate();
+        $query = $this->selectStock(
+                $this->joinLimitingCombinationsPerProduct(),
+                $this->andWhere($queryParams),
+                $this->orderBy($queryParams)
+            ) . $this->paginate();
 
         $statement = $this->connection->prepare($query);
         $this->bindStockValues($statement, $queryParams);
+
         $statement->execute();
         $rows = $statement->fetchAll();
+
         $rows = $this->addImageThumbnailPaths($rows);
 
         return $this->castNumericToInt($rows);
@@ -238,7 +238,7 @@ class ProductRepository
      * @param QueryParamsCollection $queryParams
      * @return bool|string
      */
-    public function countProductsPages(QueryParamsCollection $queryParams)
+    public function countStockPages(QueryParamsCollection $queryParams)
     {
         $query = sprintf(
             'SELECT CEIL(FOUND_ROWS() / :%s) as total_pages',
@@ -246,7 +246,8 @@ class ProductRepository
         );
 
         $statement = $this->connection->prepare($query);
-        $queryParams->bindMaxResultsParam($statement);
+        $this->bindMaxResultsValue($statement, $queryParams);
+
         $statement->execute();
 
         return (int)$statement->fetchColumn();
@@ -272,10 +273,10 @@ class ProductRepository
     }
 
     /**
-     * @param $rows
-     * @return mixed
+     * @param array $rows
+     * @return array
      */
-    private function addImageThumbnailPaths($rows)
+    private function addImageThumbnailPaths(array $rows)
     {
         array_walk($rows, function (&$row) {
             $row['product_thumbnail'] = 'N/A';
@@ -298,132 +299,39 @@ class ProductRepository
     }
 
     /**
-     * @param null $selectClause
      * @param string $leftJoinClause
      * @param string $andWhereClause
-     * @param null $groupByClause
      * @param null $orderByClause
      * @return mixed
      */
-    private function selectProductsStock(
-        $selectClause = null,
+    private function selectStock(
         $leftJoinClause = '',
         $andWhereClause = '',
-        $groupByClause = null,
         $orderByClause = null
-    ) {
-        if (is_null($groupByClause)) {
-            $groupByClause = $this->groupByProductIds();
-        }
-
-        if (is_null($selectClause)) {
-            $selectClause = $this->getProductsStockColumns();
-        }
-
+    )
+    {
         if (is_null($orderByClause)) {
             $orderByClause = $this->orderByProductIds();
         }
 
         return str_replace(
             array(
-                '{select}',
                 '{left_join}',
                 '{and_where}',
-                '{group_by}',
                 '{order_by}',
-                '{prefix}',
+                '{table_prefix}',
             ),
             array(
-                $selectClause,
                 $leftJoinClause,
                 $andWhereClause,
-                $groupByClause,
                 $orderByClause,
                 $this->tablePrefix,
             ),
             'SELECT SQL_CALC_FOUND_ROWS
-            {select}
-            FROM {prefix}product p
-            LEFT JOIN {prefix}product_attribute pa ON (p.id_product = pa.id_product)
-            LEFT JOIN {prefix}product_lang pl ON (p.id_product = pl.id_product)
-            LEFT JOIN {prefix}product_shop ps ON (
-                p.id_product = ps.id_product AND
-                ps.id_shop = :shop_id
-            )
-            LEFT JOIN {prefix}stock_available sa ON (p.id_product = sa.id_product)
-            LEFT JOIN {prefix}image ic ON (
-                pa.id_product = ic.id_product AND
-                ic.cover = 1
-            )
-            LEFT JOIN {prefix}image_shop ims ON (
-                p.id_product = ims.id_product AND
-                ic.id_image  = ims.id_image AND 
-                ims.cover = 1 
-            )
-            LEFT JOIN (
-                SELECT SUBSTRING_INDEX(
-                    GROUP_CONCAT(pai.id_image), 
-                    ",", 
-                    1
-                ) image_ids,
-                pai.id_product_attribute as combination_id
-                FROM {prefix}product_attribute_image pai
-                GROUP BY pai.id_product_attribute 
-            ) images_per_combination ON (
-                pa.id_product_attribute = images_per_combination.combination_id
-            )
-            LEFT JOIN {prefix}image i ON (
-                COALESCE(FIND_IN_SET(i.id_image, images_per_combination.image_ids), 0) > 0
-            )
-            LEFT JOIN {prefix}supplier s ON (p.id_supplier = s.id_supplier)
-            LEFT JOIN {prefix}product_attribute_combination pac ON (
-                pac.id_product_attribute = pa.id_product_attribute
-            )
-            LEFT JOIN {prefix}product_attribute_shop pas ON (
-                pas.id_product = pa.id_product AND 
-                pas.id_product_attribute = pa.id_product_attribute AND 
-                pas.id_shop = :shop_id 
-            )
-            LEFT JOIN {prefix}attribute a ON (
-                a.id_attribute = pac.id_attribute
-            )
-            LEFT JOIN {prefix}attribute_lang al ON (
-                a.id_attribute = al.id_attribute 
-                AND al.id_lang = :language_id
-                AND LENGTH(TRIM(al.name)) > 0
-            )
-            LEFT JOIN {prefix}attribute_group ag ON (
-                ag.id_attribute_group = a.id_attribute_group
-            )
-            LEFT JOIN {prefix}attribute_group_lang agl ON (
-                ag.id_attribute_group = agl.id_attribute_group 
-                AND agl.id_lang = :language_id
-                AND LENGTH(TRIM(agl.name)) > 0
-            )
-            {left_join}
-            WHERE
-            ps.id_shop = :shop_id AND
-            sa.id_shop = :shop_id AND
-            ims.id_shop = :shop_id AND
-            pl.id_lang = :language_id AND
-            sa.id_product_attribute = COALESCE(pa.id_product_attribute, 0) AND
-            p.state = :state
-            {and_where}
-            {group_by} 
-            {order_by}
-        ');
-    }
-
-    /**
-     * @return string
-     */
-    private function getProductsStockColumns()
-    {
-        return '
             p.id_product AS product_id,
             COALESCE(pa.id_product_attribute, 0) AS combination_id,
             IF (
-            COALESCE(pa.reference, 0) = 0, 
+                COALESCE(pa.reference, 0) = 0, 
                 IF (LENGTH(TRIM(p.reference)) > 0, p.reference, "N/A"),
                 IF (LENGTH(TRIM(pa.reference)) > 0, pa.reference, "N/A")
             ) AS product_reference,
@@ -444,31 +352,102 @@ class ProductRepository
             sa.quantity as product_available_quantity,
             sa.physical_quantity as product_physical_quantity,
             sa.reserved_quantity as product_reserved_quantity
-        ';
+            FROM {table_prefix}product p
+            LEFT JOIN {table_prefix}product_attribute pa ON (p.id_product = pa.id_product)
+            LEFT JOIN {table_prefix}product_lang pl ON (p.id_product = pl.id_product)
+            LEFT JOIN {table_prefix}product_shop ps ON (
+                p.id_product = ps.id_product AND
+                ps.id_shop = :shop_id
+            )
+            LEFT JOIN {table_prefix}stock_available sa ON (p.id_product = sa.id_product)
+            LEFT JOIN {table_prefix}image ic ON (
+                pa.id_product = ic.id_product AND
+                ic.cover = 1
+            )
+            LEFT JOIN {table_prefix}image_shop ims ON (
+                p.id_product = ims.id_product AND
+                ic.id_image  = ims.id_image AND 
+                ims.cover = 1 
+            )
+            LEFT JOIN (
+                SELECT SUBSTRING_INDEX(
+                    GROUP_CONCAT(pai.id_image), 
+                    ",", 
+                    1
+                ) image_ids,
+                pai.id_product_attribute as combination_id
+                FROM {table_prefix}product_attribute_image pai
+                GROUP BY pai.id_product_attribute 
+            ) images_per_combination ON (
+                pa.id_product_attribute = images_per_combination.combination_id
+            )
+            LEFT JOIN {table_prefix}image i ON (
+                COALESCE(FIND_IN_SET(i.id_image, images_per_combination.image_ids), 0) > 0
+            )
+            LEFT JOIN {table_prefix}supplier s ON (p.id_supplier = s.id_supplier)
+            LEFT JOIN {table_prefix}product_attribute_combination pac ON (
+                pac.id_product_attribute = pa.id_product_attribute
+            )
+            LEFT JOIN {table_prefix}product_attribute_shop pas ON (
+                pas.id_product = pa.id_product AND 
+                pas.id_product_attribute = pa.id_product_attribute AND 
+                pas.id_shop = :shop_id 
+            )
+            LEFT JOIN {table_prefix}attribute a ON (
+                a.id_attribute = pac.id_attribute
+            )
+            LEFT JOIN {table_prefix}attribute_lang al ON (
+                a.id_attribute = al.id_attribute 
+                AND al.id_lang = :language_id
+                AND LENGTH(TRIM(al.name)) > 0
+            )
+            LEFT JOIN {table_prefix}attribute_group ag ON (
+                ag.id_attribute_group = a.id_attribute_group
+            )
+            LEFT JOIN {table_prefix}attribute_group_lang agl ON (
+                ag.id_attribute_group = agl.id_attribute_group 
+                AND agl.id_lang = :language_id
+                AND LENGTH(TRIM(agl.name)) > 0
+            )
+            {left_join}
+            WHERE
+            ps.id_shop = :shop_id AND
+            sa.id_shop = :shop_id AND
+            ims.id_shop = :shop_id AND
+            pl.id_lang = :language_id AND
+            sa.id_product_attribute = COALESCE(pa.id_product_attribute, 0) AND
+            p.state = :state
+            {and_where}
+            GROUP BY p.id_product, COALESCE(pa.id_product_attribute, 0) 
+            {order_by}
+        ');
     }
 
     /**
      * @return string
      */
-    private function joinCeilingCombinationsPerProduct()
+    private function joinLimitingCombinationsPerProduct()
     {
         return 'LEFT JOIN (
             SELECT SUBSTRING_INDEX(
                 GROUP_CONCAT(pa.id_product_attribute), 
                 \',\', 
                 :max_combinations_per_product
-            ) product_attribute_ids 
-            FROM {prefix}product_attribute pa 
+            ) product_attribute_ids
+            FROM {table_prefix}product_attribute pa 
             GROUP BY pa.id_product
         ) combinations_per_product ON (
-            COALESCE(FIND_IN_SET(pa.id_product_attribute, combinations_per_product.product_attribute_ids), 0) > 0
+            COALESCE(
+                FIND_IN_SET(pa.id_product_attribute, combinations_per_product.product_attribute_ids), 
+                0
+            ) > 0
         ) ';
     }
 
     /**
      * @return string
      */
-    private function andWhereCeilingCombinationsPerProduct()
+    private function andWhereLimitingCombinationsPerProduct()
     {
         return 'AND (
             ISNULL(pa.id_product_attribute) OR
@@ -492,7 +471,7 @@ class ProductRepository
         $statement->bindValue('state', Product::STATE_SAVED, PDO::PARAM_INT);
 
         if ($queryParams) {
-            $queryParams->bindValuesInStatement($statement);
+            $this->bindValuesInStatement($statement, $queryParams);
             $statement->bindValue('max_combinations_per_product', self::MAX_COMBINATIONS_PER_PRODUCT, PDO::PARAM_INT);
         }
 
@@ -511,14 +490,6 @@ class ProductRepository
     }
 
     /**
-     * @return string
-     */
-    private function groupByProductIds()
-    {
-        return 'GROUP BY p.id_product, COALESCE(pa.id_product_attribute, 0)';
-    }
-
-    /**
      * @param QueryParamsCollection $queryParams
      * @return string
      */
@@ -527,7 +498,7 @@ class ProductRepository
         $filter = $queryParams->getSqlFilter();
         $filter = strtr($filter, array('{product_id}' => 'p.id_product'));
 
-        return $this->andWhereCeilingCombinationsPerProduct() . $filter;
+        return $this->andWhereLimitingCombinationsPerProduct() . $filter;
     }
 
     /**
@@ -566,4 +537,32 @@ class ProductRepository
             QueryParamsCollection::SQL_PARAM_MAX_RESULTS
         );
     }
+
+    /**
+     * @param Statement $statement
+     * @param QueryParamsCollection $queryParams
+     */
+    private function bindValuesInStatement(Statement $statement, QueryParamsCollection $queryParams)
+    {
+        $sqlParams = $queryParams->getSqlParams();
+
+        foreach ($sqlParams as $name => $value) {
+            $statement->bindValue($name, $value, PDO::PARAM_INT);
+        }
+    }
+
+    /**
+     * @param Statement $statement
+     * @param QueryParamsCollection $queryParams
+     */
+    private function bindMaxResultsValue(Statement $statement, QueryParamsCollection $queryParams)
+    {
+        $paginationParams = $queryParams->getSqlPaginationParams();
+        $statement->bindValue(
+            QueryParamsCollection::SQL_PARAM_MAX_RESULTS,
+            $paginationParams[QueryParamsCollection::SQL_PARAM_MAX_RESULTS],
+            PDO::PARAM_INT
+        );
+    }
+
 }

--- a/src/PrestaShopBundle/Exception/InvalidPaginationParamsException.php
+++ b/src/PrestaShopBundle/Exception/InvalidPaginationParamsException.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Exception;
+
+use OutOfBoundsException;
+use Exception;
+
+class InvalidPaginationParamsException extends OutOfBoundsException
+{
+    /**
+     * @param string $message
+     * @param int $code
+     * @param Exception|null $previous
+     */
+    public function __construct(
+        $message = '',
+        $code = 0,
+        Exception $previous = null
+    )
+    {
+        if ($message == '') {
+            $message = 'A page index should be an integer greater than 1.';
+        }
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -300,8 +300,8 @@ services:
     prestashop.core.api.stock.movements_collection:
         class: PrestaShopBundle\Api\Stock\MovementsCollection
 
-    prestashop.core.api.stock.product_repository:
-        class: PrestaShopBundle\Entity\Repository\Stock\ProductRepository
+    prestashop.core.api.stock.repository:
+        class: PrestaShopBundle\Entity\Repository\StockRepository
         arguments:
             - "@doctrine.dbal.default_connection"
             - "@prestashop.adapter.legacy.context"
@@ -314,7 +314,7 @@ services:
         properties:
             logger: "@logger"
             movements: "@prestashop.core.api.stock.movements_collection"
-            productRepository: "@prestashop.core.api.stock.product_repository"
+            stockRepository: "@prestashop.core.api.stock.repository"
             queryParams: "@prestashop.core.api.query_params_collection"
 
     # Managers

--- a/tests/Integration/PrestaShopBundle/Api/QueryParamsCollectionTest.php
+++ b/tests/Integration/PrestaShopBundle/Api/QueryParamsCollectionTest.php
@@ -172,42 +172,42 @@ class QueryParamsCollectionTest extends WebTestCase
             array('product', null, '1', array(
                 'ORDER BY {product} ',
                 array(
-                    'max_result' => 1,
+                    'max_results' => 1,
                     'first_result' => 0
                 )
             )),
             array('reference DESC', '3', null, array(
                 'ORDER BY {reference} DESC ',
                 array(
-                    'max_result' => 100,
+                    'max_results' => 100,
                     'first_result' => 200
                 )
             )),
             array('supplier desc', null, null, array(
                 'ORDER BY {supplier} DESC ',
                 array(
-                    'max_result' => 100,
+                    'max_results' => 100,
                     'first_result' => 0
                 )
             )),
             array('available_quantity DESC', null, null, array(
                 'ORDER BY {available_quantity} DESC ',
                 array(
-                    'max_result' => 100,
+                    'max_results' => 100,
                     'first_result' => 0
                 )
             )),
             array('available_quantity DESC', '2', '4', array(
                 'ORDER BY {available_quantity} DESC ',
                 array(
-                    'max_result' => 4,
+                    'max_results' => 4,
                     'first_result' => 4
                 )
             )),
             array('physical_quantity', '3', '3', array(
                 'ORDER BY {physical_quantity} ',
                 array(
-                    'max_result' => 3,
+                    'max_results' => 3,
                     'first_result' => 6
                 )
             )),

--- a/tests/Integration/PrestaShopBundle/Api/QueryParamsCollectionTest.php
+++ b/tests/Integration/PrestaShopBundle/Api/QueryParamsCollectionTest.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Tests\Integration\PrestaShopBundle\Api;
 
+use Exception;
 use PrestaShopBundle\Api\QueryParamsCollection;
 use Prophecy\Prophet;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -49,6 +50,48 @@ class QueryParamsCollectionTest extends WebTestCase
     {
         $this->prophet = new Prophet();
         $this->queryParams = new QueryParamsCollection();
+    }
+
+    /**
+     * @dataProvider getInvalidPaginationParams
+     *
+     * @test
+     *
+     * @param $pageIndex
+     * @param $pageSize
+     */
+    public function it_should_raise_an_exception_on_invalid_pagination_params($pageIndex, $pageSize)
+    {
+        try {
+            $this->it_should_make_query_params_from_a_request(
+                'product',
+                $pageIndex,
+                $pageSize,
+                array()
+            );
+            $this->fail('Invalid pagination params should raise an exception');
+        } catch (Exception $exception) {
+            $expectedInstanceOf = '\PrestaShopBundle\Exception\InvalidPaginationParamsException';
+            $this->assertInstanceOf(
+                $expectedInstanceOf,
+                $exception,
+                sprintf('It should raise an instance of %s', $expectedInstanceOf)
+            );
+        }
+    }
+
+    public function getInvalidPaginationParams()
+    {
+        return array(
+            array(
+                $pageIndex = 0,
+                $pageSize = QueryParamsCollection::DEFAULT_PAGE_SIZE
+            ),
+            array(
+                $pageIndex = 1,
+                $pageSize = QueryParamsCollection::DEFAULT_PAGE_SIZE + 1
+            ),
+        );
     }
 
     /**
@@ -86,14 +129,14 @@ class QueryParamsCollectionTest extends WebTestCase
     }
 
     /**
+     * @dataProvider getQueryParams
+     *
      * @test
      *
      * @param $orderQuery
      * @param $pageIndex
      * @param $pageSize
      * @param $expectedSqlClauses
-     *
-     * @dataProvider getQueryParams
      */
     public function it_should_make_query_params_with_filter_from_a_request(
         $orderQuery,

--- a/tests/Integration/PrestaShopBundle/Controller/Api/StockControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/StockControllerTest.php
@@ -78,16 +78,16 @@ class StockControllerTest extends WebTestCase
 
     public function testListProductsAction()
     {
-        $route = 'api_stock_list_products';
+        $routeName = 'api_stock_list_products';
 
-        $this->assertErrorResponseOnListProducts($route);
+        $this->assertErrorResponseOnListProducts($routeName);
         $this->assertOkResponseOnListProducts(
-            $route,
+            $routeName,
             array(),
             $expectedTotalPages = 1
         );
         $this->assertOkResponseOnListProducts(
-            $route,
+            $routeName,
             array('page_index' => 1, 'page_size' => 2),
             $expectedTotalPages = 23
         );
@@ -95,14 +95,15 @@ class StockControllerTest extends WebTestCase
 
     public function testListProductCombinationsAction()
     {
-        $route = 'api_stock_list_product_combinations';
+        $routeName = 'api_stock_list_product_combinations';
 
         $this->assertOkResponseOnListProducts(
-            $route,
-            array('productId' => 1)
+            $routeName,
+            array('productId' => 1),
+            $expectedTotalPages = 1
         );
         $this->assertOkResponseOnListProducts(
-            $route,
+            $routeName,
             array('productId' => 7, 'page_index' => 1, 'page_size' => 2),
             $expectedTotalPages = 3
         );

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -5,6 +5,7 @@
     <groups>
         <exclude>
             <group>admin</group>
+            <group>api</group>
         </exclude>
     </groups>
     <testsuites>


### PR DESCRIPTION
Response headers returned when requesting `GET /api/stock/7?page_size=5` with demo products

```
HTTP/1.1 200 OK
Date: Tue, 21 Mar 2017 13:30:22 GMT
Server: Apache/2.4.7 (Ubuntu)
Total-Pages: 2
Cache-Control: no-cache
Content-Length: 2396
Keep-Alive: timeout=5, max=100
Connection: Keep-Alive
Content-Type: application/json
```