### PR TITLE
Allow filtering of products stock by attributes (size, color) or features

### DIFF
--- a/src/PrestaShopBundle/Controller/Api/AttributeController.php
+++ b/src/PrestaShopBundle/Controller/Api/AttributeController.php
@@ -31,16 +31,16 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class AttributeController
 {
     /**
-     * @var \PrestaShopBundle\Entity\Repository\AttributeRepository
+     * @var \PrestaShopBundle\Entity\Repository\FeatureAttributeRepository
      */
-    public $attributeRepository;
+    public $featureAttributeRepository;
 
     /**
      * @return JsonResponse
      */
     public function listAttributesAction()
     {
-        $attributes = $this->attributeRepository->getAttributes();
+        $attributes = $this->featureAttributeRepository->getAttributes();
 
         return new JsonResponse($attributes, 200);
     }

--- a/src/PrestaShopBundle/Controller/Api/FeatureController.php
+++ b/src/PrestaShopBundle/Controller/Api/FeatureController.php
@@ -24,34 +24,24 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Tests\Integration\PrestaShopBundle\Controller\Api;
+namespace PrestaShopBundle\Controller\Api;
 
-/**
- * @group api
- * @group attribute
- */
-class AttributeControllerTest extends ApiTestCase
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class FeatureController
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $legacyContextMock = $this->mockContextAdapter();
-
-        $container = self::$kernel->getContainer();
-        $container->set('prestashop.adapter.legacy.context', $legacyContextMock->reveal());
-    }
+    /**
+     * @var \PrestaShopBundle\Entity\Repository\FeatureAttributeRepository
+     */
+    public $featureAttributeRepository;
 
     /**
-     * @test
+     * @return JsonResponse
      */
-    public function it_should_return_ok_response_when_requesting_attributes()
+    public function listFeaturesAction()
     {
-        $route = $this->router->generate('api_stock_list_attributes');
-        $this->client->request('GET', $route);
+        $features = $this->featureAttributeRepository->getFeatures();
 
-        /** @var \Symfony\Component\HttpFoundation\Response $response */
-        $response = $this->client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
+        return new JsonResponse($features, 200);
     }
 }

--- a/src/PrestaShopBundle/Entity/Repository/FeatureAttributeRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/FeatureAttributeRepository.php
@@ -31,6 +31,7 @@ use Employee;
 use PrestaShopBundle\Exception\NotImplementedException;
 use PrestaShop\PrestaShop\Adapter\LegacyContext as ContextAdapter;
 use RuntimeException;
+use Shop;
 
 class FeatureAttributeRepository
 {
@@ -50,6 +51,11 @@ class FeatureAttributeRepository
      * @var int
      */
     private $languageId;
+
+    /**
+     * @var int
+     */
+    private $shopId;
 
     /**
      * FeatureAttributeRepository constructor.
@@ -75,6 +81,17 @@ class FeatureAttributeRepository
 
         $languageId = $context->employee->id_lang;
         $this->languageId = (int)$languageId;
+
+        if (!$context->shop instanceof Shop) {
+            throw new RuntimeException('Determining the active shop requires a contextual shop instance.');
+        }
+
+        $shop = $context->shop;
+        if ($shop->getContextType() !== $shop::CONTEXT_SHOP) {
+            throw new NotImplementedException('Shop context types other than "single shop" are not supported');
+        }
+
+        $this->shopId = $shop->getContextualShopId();
     }
 
     /**
@@ -93,6 +110,10 @@ class FeatureAttributeRepository
               ORDER BY al.id_attribute
             ) AS "values"
             FROM {table_prefix}attribute a 
+            LEFT JOIN {table_prefix}attribute_shop ats ON (
+                ats.id_attribute = a.id_attribute AND 
+                ats.id_shop = :shop_id
+            )
             LEFT JOIN {table_prefix}attribute_lang al ON (
                 a.id_attribute = al.id_attribute 
                 AND al.id_lang = :language_id
@@ -100,6 +121,10 @@ class FeatureAttributeRepository
             )
             LEFT JOIN {table_prefix}attribute_group ag ON (
                 ag.id_attribute_group = a.id_attribute_group
+            )
+            LEFT JOIN {table_prefix}attribute_group_shop ags ON (
+                ags.id_attribute_group = a.id_attribute_group AND 
+                ags.id_shop = :shop_id
             )
             LEFT JOIN {table_prefix}attribute_group_lang agl ON (
                 ag.id_attribute_group = agl.id_attribute_group 
@@ -112,6 +137,56 @@ class FeatureAttributeRepository
         $statement = $this->connection->prepare($query);
 
         $statement->bindValue('language_id', $this->languageId);
+        $statement->bindValue('shop_id', $this->shopId);
+
+        $statement->execute();
+
+        $rows = $statement->fetchAll();
+        $rows = $this->explodeCollections($rows);
+
+        return $this->castNumericToInt($rows);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFeatures()
+    {
+        $query = str_replace(
+            '{table_prefix}',
+            $this->tablePrefix,
+            'SELECT
+            f.id_feature AS feature_id,
+            fl.name AS name, 
+            GROUP_CONCAT(
+              CONCAT(fvl.id_feature_value, ":", fvl.value)
+              ORDER BY fvl.id_feature_value
+            ) AS "values"
+            FROM {table_prefix}feature f 
+            LEFT JOIN {table_prefix}feature_lang fl ON (
+                f.id_feature = fl.id_feature AND
+                fl.id_lang = :language_id
+            ) 
+            LEFT JOIN {table_prefix}feature_shop fs ON (
+                fs.id_shop = :shop_id AND 
+                fs.id_feature = f.id_feature
+            ) 
+            LEFT JOIN {table_prefix}feature_value fv ON (
+                f.id_feature = fv.id_feature
+            )
+            LEFT JOIN {table_prefix}feature_value_lang fvl ON (
+                fvl.id_lang = :language_id AND
+                fvl.id_feature_value = fv.id_feature_value
+            )
+            WHERE fv.custom = 0
+            GROUP BY fv.id_feature
+            ORDER BY f.id_feature
+        ');
+
+        $statement = $this->connection->prepare($query);
+
+        $statement->bindValue('language_id', $this->languageId);
+        $statement->bindValue('shop_id', $this->shopId);
 
         $statement->execute();
 
@@ -138,8 +213,8 @@ class FeatureAttributeRepository
                 $parts = explode(':', $value);
 
                 return array(
-                  'attribute_id' => $parts[0],
-                  'name' => $parts[1],
+                    'item_id' => $parts[0],
+                    'name' => $parts[1],
                 );
             }, $row['values']);
 

--- a/src/PrestaShopBundle/Entity/Repository/FeatureAttributeRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/FeatureAttributeRepository.php
@@ -90,6 +90,7 @@ class FeatureAttributeRepository
             agl.name AS name, 
             GROUP_CONCAT(
               CONCAT(al.id_attribute, ":", al.name)
+              ORDER BY al.id_attribute
             ) AS "values"
             FROM {table_prefix}attribute a 
             LEFT JOIN {table_prefix}attribute_lang al ON (
@@ -130,6 +131,10 @@ class FeatureAttributeRepository
             $row['values'] = explode(',', $row['values']);
 
             $row['values'] = array_map(function ($value) {
+                if (false === strpos($value, ':')) {
+                    return $value;
+                }
+
                 $parts = explode(':', $value);
 
                 return array(

--- a/src/PrestaShopBundle/Entity/Repository/StockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockRepository.php
@@ -335,7 +335,8 @@ class StockRepository
             pl.name AS product_name,
             sa.quantity as product_available_quantity,
             sa.physical_quantity as product_physical_quantity,
-            sa.reserved_quantity as product_reserved_quantity
+            sa.reserved_quantity as product_reserved_quantity,
+            product_attributes.attributes AS product_attributes
             FROM {table_prefix}product p
             LEFT JOIN {table_prefix}product_attribute pa ON (p.id_product = pa.id_product)
             LEFT JOIN {table_prefix}product_lang pl ON (
@@ -398,6 +399,23 @@ class StockRepository
                 ag.id_attribute_group = agl.id_attribute_group 
                 AND agl.id_lang = :language_id
                 AND LENGTH(TRIM(agl.name)) > 0
+            )
+            LEFT JOIN (
+                SELECT GROUP_CONCAT(
+                    CONCAT(ag.id_attribute_group, ":", a.id_attribute)
+                    ORDER BY ag.id_attribute_group, a.id_attribute
+                ) AS "attributes",
+                pac.id_product_attribute
+                FROM {table_prefix}product_attribute_combination pac
+                LEFT JOIN {table_prefix}attribute a ON (
+                    pac.id_attribute = a.id_attribute 
+                )
+                LEFT JOIN {table_prefix}attribute_group ag ON (
+                    ag.id_attribute_group = a.id_attribute_group
+                )
+                GROUP BY pac.id_product_attribute
+            ) product_attributes ON (
+                product_attributes.id_product_attribute = pac.id_product_attribute
             )
             {left_join}
             WHERE
@@ -480,7 +498,8 @@ class StockRepository
         $filters = strtr($filters[$queryParams::SQL_CLAUSE_WHERE], array(
             '{product_id}' => 'p.id_product',
             '{supplier_id}' => 'p.id_supplier',
-            '{category_id}' => 'cp.id_category'
+            '{category_id}' => 'cp.id_category',
+            '{attributes}' => 'product_attributes.attributes',
         ));
 
         return $this->andWhereLimitingCombinationsPerProduct() . $filters;

--- a/src/PrestaShopBundle/Entity/Repository/StockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockRepository.php
@@ -336,7 +336,8 @@ class StockRepository
             sa.quantity as product_available_quantity,
             sa.physical_quantity as product_physical_quantity,
             sa.reserved_quantity as product_reserved_quantity,
-            product_attributes.attributes AS product_attributes
+            COALESCE(product_attributes.attributes, "") AS product_attributes,
+            COALESCE(product_features.features, "") AS product_features
             FROM {table_prefix}product p
             LEFT JOIN {table_prefix}product_attribute pa ON (p.id_product = pa.id_product)
             LEFT JOIN {table_prefix}product_lang pl ON (
@@ -416,6 +417,29 @@ class StockRepository
                 GROUP BY pac.id_product_attribute
             ) product_attributes ON (
                 product_attributes.id_product_attribute = pac.id_product_attribute
+            )
+            LEFT JOIN (
+                SELECT GROUP_CONCAT(
+                  CONCAT(f.id_feature, ":", fv.id_feature_value)
+                  ORDER BY fv.id_feature_value
+                ) AS "features",
+                fp.id_product
+                FROM {table_prefix}feature_product fp 
+                LEFT JOIN  {table_prefix}feature f ON (
+                    fp.id_feature = f.id_feature
+                )
+                LEFT JOIN {table_prefix}feature_shop fs ON (
+                    fs.id_shop = :shop_id AND 
+                    fs.id_feature = f.id_feature
+                ) 
+                LEFT JOIN {table_prefix}feature_value fv ON (
+                    f.id_feature = fv.id_feature AND
+                    fp.id_feature_value = fv.id_feature_value
+                )
+                WHERE fv.custom = 0
+                GROUP BY fp.id_product
+            ) product_features ON (
+                product_features.id_product = p.id_product
             )
             {left_join}
             WHERE
@@ -500,6 +524,7 @@ class StockRepository
             '{supplier_id}' => 'p.id_supplier',
             '{category_id}' => 'cp.id_category',
             '{attributes}' => 'product_attributes.attributes',
+            '{features}' => 'product_features.features',
         ));
 
         return $this->andWhereLimitingCombinationsPerProduct() . $filters;

--- a/src/PrestaShopBundle/Resources/config/api/routing_feature.yml
+++ b/src/PrestaShopBundle/Resources/config/api/routing_feature.yml
@@ -1,0 +1,5 @@
+api_stock_list_features:
+    path: /features
+    methods: [GET]
+    defaults:
+        _controller: prestashop.core.api.feature.controller:listFeaturesAction

--- a/src/PrestaShopBundle/Resources/config/routing.yml
+++ b/src/PrestaShopBundle/Resources/config/routing.yml
@@ -17,3 +17,7 @@ _api_category:
 _api_attribute:
     resource: "api/routing_attribute.yml"
     prefix: /api
+
+_api_feature:
+    resource: "api/routing_feature.yml"
+    prefix: /api

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -322,7 +322,7 @@ services:
             - "@prestashop.adapter.legacy.context"
             - "%database_prefix%"
 
-    prestashop.core.api.attribute.repository:
+    prestashop.core.api.feature_attribute.repository:
         class: PrestaShopBundle\Entity\Repository\FeatureAttributeRepository
         arguments:
             - "@doctrine.dbal.default_connection"
@@ -350,7 +350,12 @@ services:
     prestashop.core.api.attribute.controller:
         class: PrestaShopBundle\Controller\Api\AttributeController
         properties:
-            attributeRepository: "@prestashop.core.api.attribute.repository"
+            featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
+
+    prestashop.core.api.feature.controller:
+        class: PrestaShopBundle\Controller\Api\FeatureController
+        properties:
+            featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
 
     # Managers
     prestashop.adapter.image_manager:

--- a/tests/Integration/PrestaShopBundle/Controller/Api/AttributeControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/AttributeControllerTest.php
@@ -31,6 +31,16 @@ namespace PrestaShop\PrestaShop\Tests\Integration\PrestaShopBundle\Controller\Ap
  */
 class AttributeControllerTest extends ApiTestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        $legacyContextMock = $this->mockContextAdapter();
+
+        $container = self::$kernel->getContainer();
+        $container->set('prestashop.adapter.legacy.context', $legacyContextMock->reveal());
+    }
+
     /**
      * @test
      */

--- a/tests/Integration/PrestaShopBundle/Controller/Api/FeatureControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/FeatureControllerTest.php
@@ -28,9 +28,9 @@ namespace PrestaShop\PrestaShop\Tests\Integration\PrestaShopBundle\Controller\Ap
 
 /**
  * @group api
- * @group attribute
+ * @group feature
  */
-class AttributeControllerTest extends ApiTestCase
+class FeatureControllerTest extends ApiTestCase
 {
     public function setUp()
     {
@@ -45,9 +45,9 @@ class AttributeControllerTest extends ApiTestCase
     /**
      * @test
      */
-    public function it_should_return_ok_response_when_requesting_attributes()
+    public function it_should_return_ok_response_when_requesting_features()
     {
-        $route = $this->router->generate('api_stock_list_attributes');
+        $route = $this->router->generate('api_stock_list_features');
         $this->client->request('GET', $route);
 
         /** @var \Symfony\Component\HttpFoundation\Response $response */

--- a/tests/Integration/PrestaShopBundle/Controller/Api/StockControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/StockControllerTest.php
@@ -436,7 +436,6 @@ class StockControllerTest extends ApiTestCase
      */
     public function it_should_return_valid_response_when_requesting_stock_search_results()
     {
-
         $listProductsRoute = $this->router->generate('api_stock_list_products');
 
         $this->client->request(
@@ -459,6 +458,22 @@ class StockControllerTest extends ApiTestCase
             'GET',
             $listProductsRoute,
             array('attributes' => array('1:2', '3:14'))
+        );
+
+        $this->assertResponseBodyValidJson(200);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_valid_response_when_requesting_stock_with_features()
+    {
+        $listProductsRoute = $this->router->generate('api_stock_list_products');
+
+        $this->client->request(
+            'GET',
+            $listProductsRoute,
+            array('features' => array('5:1', '6:11'))
         );
 
         $this->assertResponseBodyValidJson(200);

--- a/tests/Integration/PrestaShopBundle/Controller/Api/StockControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/StockControllerTest.php
@@ -436,19 +436,29 @@ class StockControllerTest extends ApiTestCase
      */
     public function it_should_return_valid_response_when_requesting_stock_search_results()
     {
-        $this->assertOkResponseOnSearchProducts();
-    }
 
-    private function assertOkResponseOnSearchProducts()
-    {
-        $searchProductsRoute = $this->router->generate('api_stock_list_products');
+        $listProductsRoute = $this->router->generate('api_stock_list_products');
 
         $this->client->request(
             'GET',
-            $searchProductsRoute,
-            array('keywords' =>
-                array('Chiffon', 'demo_7', 'Size - S')
-            )
+            $listProductsRoute,
+            array('keywords' => array('Chiffon', 'demo_7', 'Size - S'))
+        );
+
+        $this->assertResponseBodyValidJson(200);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_valid_response_when_requesting_stock_with_attributes()
+    {
+        $listProductsRoute = $this->router->generate('api_stock_list_products');
+
+        $this->client->request(
+            'GET',
+            $listProductsRoute,
+            array('attributes' => array('1:2', '3:14'))
         );
 
         $this->assertResponseBodyValidJson(200);

--- a/tests/Unit/PrestaShopBundle/Api/QueryParamsCollectionTest.php
+++ b/tests/Unit/PrestaShopBundle/Api/QueryParamsCollectionTest.php
@@ -266,6 +266,7 @@ class QueryParamsCollectionTest extends PHPUnit_Framework_TestCase
             'It should provide with SQL conditions clauses on product references, names and supplier names'
         ;
         $attributesFilterMessage = 'It should provide with SQL conditions clauses on product attributes';
+        $featuresFilterMessage = 'It should provide with SQL conditions clauses on product features';
 
         return array(
             array(
@@ -355,6 +356,23 @@ class QueryParamsCollectionTest extends PHPUnit_Framework_TestCase
                         'AND FIND_IN_SET(:attribute_1, {attributes})'
                 ),
                 $attributesFilterMessage
+            ),
+            array(
+                array('features' => '5:1'),
+                array(
+                    QueryParamsCollection::SQL_CLAUSE_WHERE => 'AND ' .
+                        'FIND_IN_SET(:feature_0, {features})'
+                ),
+                $featuresFilterMessage
+            ),
+            array(
+                array('features' => array('5:1', '6:11')),
+                array(
+                    QueryParamsCollection::SQL_CLAUSE_WHERE => 'AND ' .
+                        'FIND_IN_SET(:feature_0, {features})' . "\n" .
+                        'AND FIND_IN_SET(:feature_1, {features})'
+                ),
+                $featuresFilterMessage
             )
         );
     }
@@ -374,6 +392,7 @@ class QueryParamsCollectionTest extends PHPUnit_Framework_TestCase
             'category_id',
             'keywords',
             'attributes',
+            'features',
         );
 
         array_walk($validQueryParams, function ($name) use ($testedParams, &$params) {


### PR DESCRIPTION
 * Filter products stock by attributes by accessing the following endpoint
```
GET /admin-dev/api/stock?attributes[]=1:2&attributes[]=3:14
```
For instance, attribute `1:2` matches attribute with attribute id `2`
in attributes group with attribute group id `1`.

 * List features by accessing the following endpoint
```
GET /admin-dev/api/features
```

 * Filter products stock by features by accessing the following endpoint
```
GET /admin-dev/api/stock?features[]=5:6&features[]=6:11
```
For instance, feature `5:6` matches products with feature value id `6`
among values of feature with feature id `5`.
